### PR TITLE
Return Community Pool share of LP incentives (Proposal #230 ending)

### DIFF
--- a/Params.py
+++ b/Params.py
@@ -64,5 +64,5 @@ share_14 = 0.2
 
 gauge_precision = 100000000
 
-community_pool_share = 0.20
+community_pool_share = 0.01
 total_incentive_share = 1 - community_pool_share


### PR DESCRIPTION
As stated in [Proposal 230](https://www.mintscan.io/osmosis/proposals/230)
The inflationary emissions to the community pool will be returned to normal incentives by the first thirdening (June 19th 2022), which will also ease the step change felt by liquidity providers
This will come in later than intended due to the chain halt delaying the corresponding incentives proposal (June 26th 2022)